### PR TITLE
fix(BasePlaywrightComputer): change page on new page event

### DIFF
--- a/computers/base_playwright.py
+++ b/computers/base_playwright.py
@@ -58,6 +58,8 @@ class BasePlaywrightComputer:
         self._playwright = sync_playwright().start()
         self._browser, self._page = self._get_browser_and_page()
 
+        self._listen_for_new_page(self._browser)
+
         # Set up network interception to flag URLs matching domains in BLOCKED_DOMAINS
         def handle_route(route, request):
 
@@ -145,6 +147,12 @@ class BasePlaywrightComputer:
 
     def forward(self) -> None:
         self._page.go_forward()
+
+    def _listen_for_new_page(self, browser: Browser) -> None:
+        def handle_new_page(page: Page):
+            self._page = page
+
+        browser.contexts[-1].on("page", handle_new_page)
 
     # --- Subclass hook ---
     def _get_browser_and_page(self) -> tuple[Browser, Page]:


### PR DESCRIPTION
Addresses an issue where after clicking on a search result, a new tab opened, and all the screenshots and page actions were still relative to the original page. 

I added this event handler to change the Computer's page when a new page is opened. 

## Tested

- [x] playwright with functions example
- [x] basic query from CLI