### PR TITLE
Add local page handling to LocalPlaywrightComputer

### DIFF
--- a/computers/local_playwright.py
+++ b/computers/local_playwright.py
@@ -18,7 +18,32 @@ class LocalPlaywrightComputer(BasePlaywrightComputer):
             args=launch_args,
             env={}
         )
-        page = browser.new_page()
+        
+        context = browser.new_context()
+        
+        # Add event listeners for page creation and closure
+        context.on("page", self._handle_new_page)
+        
+        page = context.new_page()
         page.set_viewport_size({"width": width, "height": height})
+        page.on("close", self._handle_page_close)
+
         page.goto("https://bing.com")
+        
         return browser, page
+        
+    def _handle_new_page(self, page: Page):
+        """Handle the creation of a new page."""
+        print("New page created")
+        self._page = page
+        page.on("close", self._handle_page_close)
+        
+    def _handle_page_close(self, page: Page):
+        """Handle the closure of a page."""
+        print("Page closed")
+        if self._page == page:
+            if self._browser.contexts[0].pages:
+                self._page = self._browser.contexts[0].pages[-1]
+            else:
+                print("Warning: All pages have been closed.")
+                self._page = None


### PR DESCRIPTION
## Problem
The current LocalPlaywrightComputer implementation does not properly handle new browser tabs events.

## Solution
Added page handling functionality to LocalPlaywrightComputer similar to BrowserbaseBrowser:

- Added browser context creation instead of direct page creation
- Added event listeners for new tabs and page closing
- Implemented proper page switching when active page is closed

When a new tab is created, the terminal now shows "New page created" message and properly switches to it.