### PR TITLE
Fix typo in the sample prompt (just replace "naviate" -> "navigate").

### DIFF
--- a/examples/playwright_with_custom_functions.py
+++ b/examples/playwright_with_custom_functions.py
@@ -33,7 +33,7 @@ def main():
         items = [
             {
                 "role": "developer",
-                "content": "Use the additional back() and goto() functions to naviate the browser. If you see nothing, trying going to Google.",
+                "content": "Use the additional back() and goto() functions to navigate the browser. If you see nothing, trying going to Google.",
             }
         ]
         while True:


### PR DESCRIPTION
naviate -> navigate