### PR TITLE
remove duplicate get_current_url() method

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8,7 +8,6 @@ from computers import (
     DockerComputer,
 )
 
-
 def acknowledge_safety_check_callback(message: str) -> bool:
     response = input(
         f"Safety Check Warning: {message}\nDo you want to acknowledge and proceed? (y/n): "

--- a/cli.py
+++ b/cli.py
@@ -73,7 +73,13 @@ def main():
         items = []
 
         while True:
-            user_input = args.input or input("> ")
+            try:
+                user_input = args.input or input("> ")
+                if user_input == 'exit':
+                    break
+            except EOFError as e:
+                print(f"An error occurred: {e}")
+                break
             items.append({"role": "user", "content": user_input})
             output_items = agent.run_full_turn(
                 items,

--- a/computers/base_playwright.py
+++ b/computers/base_playwright.py
@@ -130,9 +130,6 @@ class BasePlaywrightComputer:
             self._page.mouse.move(point["x"], point["y"])
         self._page.mouse.up()
 
-    def get_current_url(self) -> str:
-        return self._page.url
-
     # --- Extra browser-oriented actions ---
     def goto(self, url: str) -> None:
         try:


### PR DESCRIPTION
And exit the user enters `exit` and exit gracefully if the user presses <kbd>⌘ Command</kbd> <kbd>D</kbd> (tested on Mac)

