### PR TITLE
fix: press keys simultaneously

### DIFF
--- a/computers/base_playwright.py
+++ b/computers/base_playwright.py
@@ -117,9 +117,11 @@ class BasePlaywrightComputer:
         self._page.mouse.move(x, y)
 
     def keypress(self, keys: List[str]) -> None:
-        for key in keys:
-            mapped_key = CUA_KEY_TO_PLAYWRIGHT_KEY.get(key.lower(), key)
-            self._page.keyboard.press(mapped_key)
+        mapped_keys = [CUA_KEY_TO_PLAYWRIGHT_KEY.get(key.lower(), key) for key in keys]
+        for key in mapped_keys:
+            self._page.keyboard.down(key)
+        for key in reversed(mapped_keys):
+            self._page.keyboard.up(key)
 
     def drag(self, path: List[Dict[str, int]]) -> None:
         if not path:


### PR DESCRIPTION
The README gives this example for the usage of `keypress`:
https://github.com/openai/openai-cua-sample-app/blob/80d04f28371e0251abebd5acb69d2f3d42cf09fb/README.md?plain=1#L87

The current implementation for `keypress`, however, seems to press the keys sequentially rather than at the same time:
https://github.com/openai/openai-cua-sample-app/blob/80d04f28371e0251abebd5acb69d2f3d42cf09fb/computers/base_playwright.py#L119-L122

In other words, rather than press "Control" and "C" at the same time, it will press "Control", release it, and then press "C".

This PR presses the keys simultaneously.