### PR TITLE
Remove spaces to the left and right of the equals sign.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # rename this to .env and fill in your own keys
 
 OPENAI_API_KEY="sk-proj-123"
-OPENAI_ORG = "org-123"
+OPENAI_ORG="org-123"
 
 BROWSERBASE_API_KEY="00000000-0000-0000-0000-000000000000"
 BROWSERBASE_PROJECT_ID="bb_live_00000000-00000"


### PR DESCRIPTION
The sample environment variable configuration file has been revised.
It will now be processed correctly when the source command is executed.

```
set -a
source .env.example
set +a
```
