### PR TITLE
Add model picker and disable unsafe exec_js by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ OPENAI_API_KEY=your_key_here pnpm test:live
 ## Execution Modes
 
 - `native`: exposes the Responses API computer tool directly. The model requests clicks, drags, typing, waits, and screenshots against the live browser session.
-- `code`: exposes a persistent Playwright JavaScript REPL through `exec_js`. The model scripts the browser rather than emitting raw computer actions.
+- `code`: exposes a persistent Playwright JavaScript REPL through `exec_js`. Because it executes model-generated JavaScript in the runner process, the public sample disables it by default.
 
-Both modes use the same scenario manifests and replay pipeline. `native` is the closest sample of the computer tool itself. `code` is the clearest sample of a browser REPL harness.
+Both modes use the same scenario manifests and replay pipeline. `native` is the default and the closest sample of the computer tool itself. `code` remains available only for isolated local experimentation when you intentionally opt in with `CUA_ENABLE_UNSAFE_CODE_TOOL=true`.
 
 ## Official Scenarios
 
@@ -130,6 +130,7 @@ Runner:
 - `HOST` (default `127.0.0.1`)
 - `PORT` (default `4001`)
 - `CUA_DEFAULT_MODEL` (default `gpt-5.4`)
+- `CUA_ENABLE_UNSAFE_CODE_TOOL` (default disabled; set to `true` only for isolated local experimentation with `exec_js`)
 - `CUA_RESPONSES_MODE` (`auto`, `fallback`, or `live`)
 
 Web:

--- a/apps/demo-web/app/ui/operator-console/OperatorConsole.test.tsx
+++ b/apps/demo-web/app/ui/operator-console/OperatorConsole.test.tsx
@@ -119,4 +119,68 @@ describe("OperatorConsole", () => {
       ).length,
     ).toBeGreaterThan(0);
   });
+
+  it("starts a run with the selected model", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+
+    fetchMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          eventStreamUrl: "/api/runs/run-123/events",
+          replayUrl: "/api/runs/run-123/replay",
+          runId: "run-123",
+          status: "running",
+        }),
+        ok: true,
+        status: 200,
+      } as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          browser: undefined,
+          eventStreamUrl: "/api/runs/run-123/events",
+          events: [],
+          replayUrl: "/api/runs/run-123/replay",
+          run: {
+            browserMode: "headless",
+            id: "run-123",
+            labId: "kanban",
+            maxResponseTurns: 24,
+            mode: "code",
+            model: "gpt-5.4-mini",
+            prompt: scenario.defaultPrompt,
+            scenarioId: scenario.id,
+            startedAt: "2026-03-16T00:00:00.000Z",
+            status: "running",
+            verificationEnabled: false,
+          },
+          scenario,
+          workspacePath: "/tmp/run-123",
+        }),
+        ok: true,
+        status: 200,
+      } as Response);
+
+    render(
+      <OperatorConsole
+        initialRunnerIssue={null}
+        runnerBaseUrl="http://127.0.0.1:4001"
+        scenarios={[scenario]}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText("Model"), "gpt-5.4-mini");
+    await user.click(screen.getByRole("button", { name: "Start Run" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const requestBody = JSON.parse(String(requestInit.body)) as {
+      model?: string;
+    };
+
+    expect(requestBody.model).toBe("gpt-5.4-mini");
+  });
 });

--- a/apps/demo-web/app/ui/operator-console/OperatorConsole.tsx
+++ b/apps/demo-web/app/ui/operator-console/OperatorConsole.tsx
@@ -33,6 +33,7 @@ export function OperatorConsole({
     handleStopRun,
     matchingWorkspaceState,
     maxResponseTurns,
+    model,
     mode,
     pendingAction,
     prompt,
@@ -46,6 +47,7 @@ export function OperatorConsole({
     selectedScenarioId,
     setBrowserMode,
     setMaxResponseTurns,
+    setModel,
     setMode,
     setPrompt,
     setStreamLogs,
@@ -145,9 +147,11 @@ export function OperatorConsole({
               browserMode={browserMode}
               controlsLocked={controlsLocked}
               maxResponseTurns={maxResponseTurns}
+              model={model}
               mode={mode}
               onBrowserModeChange={setBrowserMode}
               onMaxResponseTurnsChange={setMaxResponseTurns}
+              onModelChange={setModel}
               onModeChange={setMode}
               onPromptChange={setPrompt}
               onResetWorkspace={handleResetWorkspace}

--- a/apps/demo-web/app/ui/operator-console/RunControls.tsx
+++ b/apps/demo-web/app/ui/operator-console/RunControls.tsx
@@ -10,18 +10,22 @@ import type {
 import {
   browserHelpText,
   engineHelpText,
+  modelHelpText,
+  supportedRunModels,
   turnBudgetHelpText,
   verificationHelpText,
 } from "./helpers";
-import type { ActionButtonsProps } from "./types";
+import type { ActionButtonsProps, RunModel } from "./types";
 
 type RunControlsProps = ActionButtonsProps & {
   browserMode: BrowserMode;
   controlsLocked: boolean;
   maxResponseTurns: ResponseTurnBudget;
+  model: RunModel;
   mode: ExecutionMode;
   onBrowserModeChange: (value: BrowserMode) => void;
   onMaxResponseTurnsChange: (value: ResponseTurnBudget) => void;
+  onModelChange: (value: RunModel) => void;
   onModeChange: (value: ExecutionMode) => void;
   onPromptChange: (value: string) => void;
   onScenarioChange: (value: string) => void;
@@ -131,9 +135,11 @@ export function RunControls({
   browserMode,
   controlsLocked,
   maxResponseTurns,
+  model,
   mode,
   onBrowserModeChange,
   onMaxResponseTurnsChange,
+  onModelChange,
   onModeChange,
   onPromptChange,
   onScenarioChange,
@@ -211,6 +217,29 @@ export function RunControls({
               ]}
               value={mode}
             />
+          </div>
+
+          <div className="railField">
+            <div className="fieldLabel">
+              <label htmlFor="run-model">Model</label>
+              <InfoPopover
+                id="model-help-popover"
+                label="Model"
+                text={modelHelpText}
+              />
+            </div>
+            <select
+              disabled={controlsLocked}
+              id="run-model"
+              onChange={(event) => onModelChange(event.target.value as RunModel)}
+              value={model}
+            >
+              {supportedRunModels.map((option) => (
+                <option key={option} value={option}>
+                  {option === "gpt-5.4" ? "GPT-5.4" : "GPT-5.4 mini"}
+                </option>
+              ))}
+            </select>
           </div>
 
           <div className="railField">

--- a/apps/demo-web/app/ui/operator-console/helpers.ts
+++ b/apps/demo-web/app/ui/operator-console/helpers.ts
@@ -11,17 +11,29 @@ import {
 import type {
   ActivityItem,
   LogEntry,
+  RunModel,
   RunnerIssue,
   TranscriptEntry,
 } from "./types";
 
-export const defaultRunModel =
-  process.env.NEXT_PUBLIC_CUA_DEFAULT_MODEL ?? "gpt-5.4";
+export const supportedRunModels: RunModel[] = ["gpt-5.4", "gpt-5.4-mini"];
+
+function coerceRunModel(value: string): RunModel {
+  return supportedRunModels.includes(value as RunModel)
+    ? (value as RunModel)
+    : "gpt-5.4";
+}
+
+export const defaultRunModel = coerceRunModel(
+  process.env.NEXT_PUBLIC_CUA_DEFAULT_MODEL ?? "gpt-5.4",
+);
 export const defaultMaxResponseTurns = Number(
   process.env.NEXT_PUBLIC_CUA_DEFAULT_MAX_RESPONSE_TURNS ?? "24",
 ) as ResponseTurnBudget;
 export const engineHelpText =
   "Native drives the browser runtime directly for clicks, drags, typing, and screenshots. Code uses a persistent Playwright REPL for scripted browser control.";
+export const modelHelpText =
+  "Choose which model to use when the operator console starts a run.";
 export const browserHelpText =
   "Headless runs the browser off-screen. Visible opens the browser window so you can watch the session live as it runs.";
 export const turnBudgetHelpText =

--- a/apps/demo-web/app/ui/operator-console/helpers.ts
+++ b/apps/demo-web/app/ui/operator-console/helpers.ts
@@ -31,7 +31,7 @@ export const defaultMaxResponseTurns = Number(
   process.env.NEXT_PUBLIC_CUA_DEFAULT_MAX_RESPONSE_TURNS ?? "24",
 ) as ResponseTurnBudget;
 export const engineHelpText =
-  "Native drives the browser runtime directly for clicks, drags, typing, and screenshots. Code uses a persistent Playwright REPL for scripted browser control.";
+  "Native drives the browser runtime directly for clicks, drags, typing, and screenshots. Code uses a persistent Playwright REPL and is disabled by default in the public sample unless CUA_ENABLE_UNSAFE_CODE_TOOL=true is set on the runner.";
 export const modelHelpText =
   "Choose which model to use when the operator console starts a run.";
 export const browserHelpText =

--- a/apps/demo-web/app/ui/operator-console/types.ts
+++ b/apps/demo-web/app/ui/operator-console/types.ts
@@ -43,6 +43,8 @@ export type ActivityItem = {
 
 export type PendingAction = "reset" | "start" | "stop" | null;
 
+export type RunModel = "gpt-5.4" | "gpt-5.4-mini";
+
 export type RunnerIssue = {
   code: string;
   error: string;

--- a/apps/demo-web/app/ui/operator-console/useRunStream.ts
+++ b/apps/demo-web/app/ui/operator-console/useRunStream.ts
@@ -30,7 +30,13 @@ import {
   mapRunEventToActivity,
   parseRunnerIssue,
 } from "./helpers";
-import type { LogEntry, PendingAction, RunnerIssue, TranscriptEntry } from "./types";
+import type {
+  LogEntry,
+  PendingAction,
+  RunModel,
+  RunnerIssue,
+  TranscriptEntry,
+} from "./types";
 
 const emptyScreenshots: NonNullable<RunDetail["browser"]>["screenshots"] = [];
 
@@ -88,6 +94,7 @@ export function useRunStream({
   const [verificationEnabled, setVerificationEnabled] = useState(false);
   const [maxResponseTurns, setMaxResponseTurns] =
     useState<ResponseTurnBudget>(defaultMaxResponseTurns);
+  const [model, setModel] = useState<RunModel>(defaultRunModel);
   const [prompt, setPrompt] = useState(initialScenario?.defaultPrompt ?? "");
   const [streamLogs, setStreamLogs] = useState(true);
   const [activeRun, setActiveRun] = useState<RunDetail | null>(null);
@@ -411,7 +418,7 @@ export function useRunStream({
             browserMode,
             maxResponseTurns,
             mode,
-            model: defaultRunModel,
+            model,
             prompt,
             scenarioId: selectedScenario.id,
             verificationEnabled,
@@ -666,6 +673,7 @@ export function useRunStream({
     latestScreenshot,
     matchingWorkspaceState,
     maxResponseTurns,
+    model,
     mode,
     pendingAction,
     prompt,
@@ -679,6 +687,7 @@ export function useRunStream({
     selectedScenarioId,
     setBrowserMode,
     setMaxResponseTurns,
+    setModel,
     setMode,
     setPrompt,
     setStreamLogs,

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -59,6 +59,7 @@ How verification works:
 
 ## Notes On Modes
 
-- `code` mode uses the browser REPL tool (`exec_js`) to drive the same lab.
-- `native` mode uses the computer tool directly.
+- `native` mode uses the computer tool directly and is the public default.
+- `code` mode uses the browser REPL tool (`exec_js`) to drive the same lab, but the public sample disables it by default because it executes model-generated JavaScript in the runner process.
+- Set `CUA_ENABLE_UNSAFE_CODE_TOOL=true` only for isolated local experimentation if you intentionally want to re-enable `code` mode.
 - Verification is the same either way because it reads the final lab state, not the agent transcript.

--- a/packages/runner-core/src/responses-loop.ts
+++ b/packages/runner-core/src/responses-loop.ts
@@ -336,7 +336,7 @@ function buildCodeToolDefinitions() {
             description: [
               "JavaScript to execute in an async Playwright REPL.",
               "Persist state across calls with globalThis.",
-              "Available globals: console.log, display(base64Image), Buffer, browser, context, page.",
+              "Available globals: console.log, display(base64Image), browser, context, page.",
               "Prefer locator-based waits and domcontentloaded load-state waits over fixed delays.",
             ].join("\n"),
             type: "string",
@@ -690,7 +690,6 @@ export async function runResponsesCodeLoop(
 ): Promise<ResponsesLoopResult> {
   const jsOutputRef: { current: ToolOutput[] } = { current: [] };
   const sandbox = {
-    Buffer,
     browser: input.session.browser,
     console: {
       log: (...values: unknown[]) => {

--- a/packages/runner-core/src/scenario-runtime.ts
+++ b/packages/runner-core/src/scenario-runtime.ts
@@ -71,6 +71,10 @@ const defaultHeadfulHoldMs = 3_500;
 const defaultPromptRequestedHoldMs = 5_000;
 const maxHeadfulHoldMs = 15_000;
 
+export function isUnsafeCodeToolEnabled(env: NodeJS.ProcessEnv = process.env) {
+  return env.CUA_ENABLE_UNSAFE_CODE_TOOL === "true";
+}
+
 export function assertActive(signal: AbortSignal) {
   if (signal.aborted) {
     throw new RunAbortedError();
@@ -234,6 +238,15 @@ export function createLiveResponsesUnavailableError(message: string) {
   });
 }
 
+export function createUnsafeCodeModeDisabledError(message: string) {
+  return new RunnerCoreError(message, {
+    code: "unsafe_code_mode_disabled",
+    hint:
+      "Use native mode instead. Only set CUA_ENABLE_UNSAFE_CODE_TOOL=true on an isolated machine if you intentionally want to experiment with exec_js locally.",
+    statusCode: 400,
+  });
+}
+
 export async function failLiveResponsesUnavailable(
   context: RunExecutionContext,
   message: string,
@@ -245,6 +258,19 @@ export async function failLiveResponsesUnavailable(
     type: "run_failed",
   });
   throw createLiveResponsesUnavailableError(message);
+}
+
+export async function failUnsafeCodeModeDisabled(
+  context: RunExecutionContext,
+  message: string,
+) {
+  await context.emitEvent({
+    detail: context.detail.run.prompt,
+    level: "error",
+    message,
+    type: "run_failed",
+  });
+  throw createUnsafeCodeModeDisabledError(message);
 }
 
 export function createUnsupportedScenarioError(scenarioId: string) {

--- a/packages/runner-core/src/scenarios/booking.ts
+++ b/packages/runner-core/src/scenarios/booking.ts
@@ -13,7 +13,9 @@ import {
   runResponsesNativeComputerLoop,
 } from "../responses-loop.js";
 import {
+  failUnsafeCodeModeDisabled,
   failLiveResponsesUnavailable,
+  isUnsafeCodeToolEnabled,
   type RunExecutionContext,
   type RunExecutor,
   runWorkspaceLabBrowserFlow,
@@ -21,9 +23,16 @@ import {
 
 const liveOnlyMessage =
   "Booking lab requires the live Responses API. Deterministic fallback is disabled to keep the operator prompt as the only source of truth.";
+const codeModeDisabledMessage =
+  "Booking code mode is disabled by default in the public sample because exec_js executes model-generated JavaScript in the runner process.";
 
 class BookingCodeExecutor implements RunExecutor {
   async execute(context: RunExecutionContext) {
+    if (!isUnsafeCodeToolEnabled()) {
+      await failUnsafeCodeModeDisabled(context, codeModeDisabledMessage);
+      return;
+    }
+
     const client = createDefaultResponsesClient();
 
     if (!client) {

--- a/packages/runner-core/src/scenarios/kanban.ts
+++ b/packages/runner-core/src/scenarios/kanban.ts
@@ -15,7 +15,9 @@ import {
   runResponsesNativeComputerLoop,
 } from "../responses-loop.js";
 import {
+  failUnsafeCodeModeDisabled,
   failLiveResponsesUnavailable,
+  isUnsafeCodeToolEnabled,
   type RunExecutionContext,
   type RunExecutor,
   runWorkspaceLabBrowserFlow,
@@ -31,9 +33,16 @@ function formatBoardState(
 
 const liveOnlyMessage =
   "Kanban lab requires the live Responses API. Deterministic fallback is disabled to keep the operator prompt as the only source of truth.";
+const codeModeDisabledMessage =
+  "Kanban code mode is disabled by default in the public sample because exec_js executes model-generated JavaScript in the runner process.";
 
 class KanbanCodeExecutor implements RunExecutor {
   async execute(context: RunExecutionContext) {
+    if (!isUnsafeCodeToolEnabled()) {
+      await failUnsafeCodeModeDisabled(context, codeModeDisabledMessage);
+      return;
+    }
+
     const client = createDefaultResponsesClient();
 
     if (!client) {

--- a/packages/runner-core/src/scenarios/paint.ts
+++ b/packages/runner-core/src/scenarios/paint.ts
@@ -13,7 +13,9 @@ import {
   runResponsesNativeComputerLoop,
 } from "../responses-loop.js";
 import {
+  failUnsafeCodeModeDisabled,
   failLiveResponsesUnavailable,
+  isUnsafeCodeToolEnabled,
   type RunExecutionContext,
   type RunExecutor,
   runWorkspaceLabBrowserFlow,
@@ -21,9 +23,16 @@ import {
 
 const liveOnlyMessage =
   "Paint lab requires the live Responses API. Deterministic fallback is disabled to avoid hardcoded artwork.";
+const codeModeDisabledMessage =
+  "Paint code mode is disabled by default in the public sample because exec_js executes model-generated JavaScript in the runner process.";
 
 class PaintCodeExecutor implements RunExecutor {
   async execute(context: RunExecutionContext) {
+    if (!isUnsafeCodeToolEnabled()) {
+      await failUnsafeCodeModeDisabled(context, codeModeDisabledMessage);
+      return;
+    }
+
     const client = createDefaultResponsesClient();
 
     if (!client) {

--- a/packages/runner-core/test/runner-manager.test.ts
+++ b/packages/runner-core/test/runner-manager.test.ts
@@ -10,8 +10,15 @@ import type { RunEvent } from "@cua-sample/replay-schema";
 import { RunnerManager } from "../src/index.js";
 
 const tempRoots: string[] = [];
+const originalUnsafeCodeTool = process.env.CUA_ENABLE_UNSAFE_CODE_TOOL;
 
 afterEach(async () => {
+  if (originalUnsafeCodeTool === undefined) {
+    delete process.env.CUA_ENABLE_UNSAFE_CODE_TOOL;
+  } else {
+    process.env.CUA_ENABLE_UNSAFE_CODE_TOOL = originalUnsafeCodeTool;
+  }
+
   for (const root of tempRoots.splice(0)) {
     await import("node:fs/promises").then(({ rm }) =>
       rm(root, { force: true, recursive: true }),
@@ -33,6 +40,39 @@ async function createManager(stepDelayMs = 10) {
 }
 
 describe("RunnerManager", () => {
+  it("fails code mode honestly when the unsafe exec_js path is disabled", async () => {
+    delete process.env.CUA_ENABLE_UNSAFE_CODE_TOOL;
+    const { manager } = await createManager(5);
+
+    const detail = await manager.startRun({
+      browserMode: "headless",
+      maxResponseTurns: 18,
+      mode: "code",
+      prompt: [
+        "Reorganize the board to match this requested final board state exactly.",
+        "",
+        "backlog: Refresh workspace docs",
+        "in_progress: Close nav bug triage -> Finalize analytics spec",
+        "done: Circulate launch brief -> Audit replay artifacts -> Polish stage tooltips",
+      ].join("\n"),
+      scenarioId: "kanban-reprioritize-sprint",
+    });
+
+    const failed = await manager.waitForRunStatus(detail.run.id, "failed");
+
+    expect(failed.run.status).toBe("failed");
+    expect(
+      failed.events.some(
+        (event: RunEvent) =>
+          event.type === "run_failed" &&
+          event.message.includes("disabled by default"),
+      ),
+    ).toBe(true);
+    expect(failed.run.summary?.notes).toContain(
+      "Error code: unsafe_code_mode_disabled",
+    );
+  });
+
   it("fails the kanban native executor honestly when live Responses is unavailable", async () => {
     const { manager } = await createManager(5);
 

--- a/packages/scenario-kit/src/scenarios.ts
+++ b/packages/scenario-kit/src/scenarios.ts
@@ -28,7 +28,7 @@ const scenarioCatalog = scenarioManifestSchema.array().parse([
       label: "run-scoped HTTP kanban lab",
       url: "http://127.0.0.1:3102",
     },
-    defaultMode: "code",
+    defaultMode: "native",
     supportsCodeEdits: false,
     verification: [
       {
@@ -54,7 +54,7 @@ const scenarioCatalog = scenarioManifestSchema.array().parse([
       label: "run-scoped HTTP paint lab",
       url: "http://127.0.0.1:3103",
     },
-    defaultMode: "code",
+    defaultMode: "native",
     supportsCodeEdits: false,
     verification: [
       {
@@ -80,7 +80,7 @@ const scenarioCatalog = scenarioManifestSchema.array().parse([
       label: "run-scoped HTTP booking lab",
       url: "http://127.0.0.1:3104",
     },
-    defaultMode: "code",
+    defaultMode: "native",
     supportsCodeEdits: false,
     verification: [
       {

--- a/packages/scenario-kit/test/scenarios.test.ts
+++ b/packages/scenario-kit/test/scenarios.test.ts
@@ -23,9 +23,9 @@ describe("scenario registry", () => {
 
   it("uses the expected default mode for each lab", () => {
     const defaultModeByLab = new Map([
-      ["kanban", "code"],
-      ["paint", "code"],
-      ["booking", "code"],
+      ["kanban", "native"],
+      ["paint", "native"],
+      ["booking", "native"],
     ]);
 
     for (const scenario of listScenarios()) {


### PR DESCRIPTION
## Summary
- add an advanced-settings model picker for GPT-5.4 and GPT-5.4 mini
- thread the selected model through the operator console start-run request and cover it with a UI test
- disable the public sample's unsafe `exec_js` code mode by default, switch public scenarios to `native`, and document the opt-in env flag for isolated local experimentation

## Verification
- pnpm --filter @cua-sample/runner-core test
- pnpm --filter @cua-sample/scenario-kit test
- pnpm --filter @cua-sample/demo-web test